### PR TITLE
Documentation: Added documentation for blocks defined for NAFNet implementation

### DIFF
--- a/restorers/model/nafnet/nafblock.py
+++ b/restorers/model/nafnet/nafblock.py
@@ -13,11 +13,12 @@ class SimpleGate(keras.layers.Layer):
     Simple Gate
     It splits the input of size (b,h,w,c) into tensors of size (b,h,w,c//factor) and returns their Hadamard product
 
-    Reference: NAFNet Paper (Simple Baselines for Image Restoration)
-    https://www.ecva.net/papers/eccv_2022/papers_ECCV/papers/136670017.pdf
+    Reference:
+    
+    1. [Simple Baselines for Image Restoration](https://arxiv.org/abs/2204.04676)
 
     Parameters:
-        factor: the amount by which the channels are scaled down
+        factor (Optional[int]): the amount by which the channels are scaled down
     """
 
     def __init__(self, factor: Optional[int] = 2, **kwargs) -> None:
@@ -43,15 +44,16 @@ class ChannelAttention(keras.layers.Layer):
     Channel Attention layer
 
     The block is named Squeeze-and-Excitation block (SE Block) in the original paper.
-    First the input is 'squeezed' across the spatial dimension to generate
-        a channel-wise descriptor.
-    Following that the inter channel dependency is learnt by applying
+    1. First the input is 'squeezed' across the spatial dimension to generate a
+        channel-wise descriptor.
+    2. Following that the inter channel dependency is learnt by applying
         two convolution layers.
-    Then finally, the input is rescaled by a channel-wise multiplication with the
+    3. Finally, the input is rescaled by a channel-wise multiplication with the
         output of the excitation operation.
 
-    Reference: Squeeze-and-Excitation Networks, Hu et al.
-    https://ieeexplore.ieee.org/document/8578843
+    Reference:
+    
+    1. [Squeeze-and-Excitation Networks](https://arxiv.org/abs/1709.01507)
 
     Parameters:
         channels: number of channels in input
@@ -95,8 +97,9 @@ class SimplifiedChannelAttention(keras.layers.Layer):
         is not used.
         (Check the paper/doc string of NAFBlock for more details)
 
-    Reference: NAFNet Paper (Simple Baselines for Image Restoration)
-    https://www.ecva.net/papers/eccv_2022/papers_ECCV/papers/136670017.pdf
+    Reference:
+    
+    1. [Simple Baselines for Image Restoration](https://arxiv.org/abs/2204.04676)
 
     Parameters:
         channels: number of channels in input
@@ -144,12 +147,13 @@ class NAFBlock(keras.layers.Layer):
     Using this idea, all the nonlinear activations are replaced by
         a series of Hadamard produces
 
-    Reference: NAFNet Paper (Simple Baselines for Image Restoration)
-    https://www.ecva.net/papers/eccv_2022/papers_ECCV/papers/136670017.pdf
+    Reference:
+    
+    1. [Simple Baselines for Image Restoration](https://arxiv.org/abs/2204.04676)
 
     Parameters:
-        input_channels: number of channels in the input (as NAFBlock retains the input size in the output)
-        factor: factor by which the channels must be increased before being reduced by simple gate.
+        input_channels (Optional[int]): number of channels in the input (as NAFBlock retains the input size in the output)
+        factor (Optional[float]): factor by which the channels must be increased before being reduced by simple gate.
             (Higher factor denotes higher order polynomial in multiplication. Default factor is 2)
         drop_out_rate: dropout rate
         balanced_skip_connection: adds additional trainable parameters to the skip connections.

--- a/restorers/model/nafnet/nafblock.py
+++ b/restorers/model/nafnet/nafblock.py
@@ -17,10 +17,7 @@ class SimpleGate(keras.layers.Layer):
 
     Parameters:
         factor (Optional[int]): the amount by which the channels are scaled down
-<<<<<<< HEAD
             Default factor is 2.
-=======
->>>>>>> ea3089f6eb211c37a2a28eb183312fd8a0c1d106
     """
 
     def __init__(self, factor: int = 2, **kwargs) -> None:

--- a/restorers/model/nafnet/nafblock.py
+++ b/restorers/model/nafnet/nafblock.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import tensorflow as tf
 from tensorflow import keras
 

--- a/restorers/model/nafnet/nafblock.py
+++ b/restorers/model/nafnet/nafblock.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import tensorflow as tf
 from tensorflow import keras
 
@@ -17,10 +15,11 @@ class SimpleGate(keras.layers.Layer):
     https://www.ecva.net/papers/eccv_2022/papers_ECCV/papers/136670017.pdf
 
     Parameters:
-        factor: the amount by which the channels are scaled down
+        factor (Optional[int]): the amount by which the channels are scaled down
+            Default factor is 2.
     """
 
-    def __init__(self, factor: Optional[int] = 2, **kwargs) -> None:
+    def __init__(self, factor: int = 2, **kwargs) -> None:
         super().__init__(**kwargs)
         self.factor = factor
 
@@ -148,13 +147,14 @@ class NAFBlock(keras.layers.Layer):
     https://www.ecva.net/papers/eccv_2022/papers_ECCV/papers/136670017.pdf
 
     Parameters:
-        input_channels: number of channels in the input (as NAFBlock retains the input size in the output)
-        factor: factor by which the channels must be increased before being reduced by simple gate.
+        factor (Optional[float]): factor by which the channels must be increased before being reduced by simple gate.
             (Higher factor denotes higher order polynomial in multiplication. Default factor is 2)
-        drop_out_rate: dropout rate
-        balanced_skip_connection: adds additional trainable parameters to the skip connections.
+        drop_out_rate (Optional[float]): dropout rate
+            Default value is 0.0
+        balanced_skip_connection (Optional[bool]): adds additional trainable parameters to the skip connections.
             The parameter denotes how much importance should be given to the sub block in the skip connection.
-        mode: NAFBlock has 3 mode.
+            Default value is False
+        mode (Optional[str]): NAFBlock has 3 mode.
             'plain' mode uses the PlainBlock.
                 It is derived from the restormer block, keeping the most common components
             'baseline' mode used the BaselineBlock
@@ -163,14 +163,15 @@ class NAFBlock(keras.layers.Layer):
             'nafblock' mode uses the NAFBlock
                 It derived from BaselineBlock by removing all the non-linear activation.
                 Non-linear activations are replaced by equivalent matrix multiplication operations.
+            Default mode is 'nafblock'
     """
 
     def __init__(
         self,
-        factor: Optional[int] = 2,
-        drop_out_rate: Optional[float] = 0.0,
-        balanced_skip_connection: Optional[bool] = False,
-        mode: Optional[str] = NAFBLOCK,
+        factor: int = 2,
+        drop_out_rate: float = 0.0,
+        balanced_skip_connection: bool = False,
+        mode: str = NAFBLOCK,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)

--- a/restorers/model/nafnet/nafblock.py
+++ b/restorers/model/nafnet/nafblock.py
@@ -12,7 +12,7 @@ class SimpleGate(keras.layers.Layer):
     It splits the input of size (b,h,w,c) into tensors of size (b,h,w,c//factor) and returns their Hadamard product
 
     Reference:
-    
+
     1. [Simple Baselines for Image Restoration](https://arxiv.org/abs/2204.04676)
 
     Parameters:
@@ -51,7 +51,7 @@ class ChannelAttention(keras.layers.Layer):
         output of the excitation operation.
 
     Reference:
-    
+
     1. [Squeeze-and-Excitation Networks](https://arxiv.org/abs/1709.01507)
 
     Parameters:
@@ -97,7 +97,7 @@ class SimplifiedChannelAttention(keras.layers.Layer):
         (Check the paper/doc string of NAFBlock for more details)
 
     Reference:
-    
+
     1. [Simple Baselines for Image Restoration](https://arxiv.org/abs/2204.04676)
 
     Parameters:
@@ -127,51 +127,51 @@ class SimplifiedChannelAttention(keras.layers.Layer):
 
 class NAFBlock(keras.layers.Layer):
     """
-    NAFBlock (Nonlinear Activation Free Block)
+        NAFBlock (Nonlinear Activation Free Block)
 
-    The authors first define a plain block by retaining the most used operations
-        from the restormer block.
-    In the plain block layer normalization and channel attention is added to make
-        the baseline block.
-    NAFBlock is constructed by removing all the non-linear activations from
-        the baseline block.
+        The authors first define a plain block by retaining the most used operations
+            from the restormer block.
+        In the plain block layer normalization and channel attention is added to make
+            the baseline block.
+        NAFBlock is constructed by removing all the non-linear activations from
+            the baseline block.
 
-    The authors have the idea that any operations of the form,
-    .. math::
-        f(X) \dot \sigma(g(Y))
-    (where f and g are feature maps and \sigma is activation function)
-    can be simplified to the form
-    .. math::
-        X \dot g(Y)
-    Using this idea, all the nonlinear activations are replaced by
-        a series of Hadamard produces
+        The authors have the idea that any operations of the form,
+        .. math::
+            f(X) \dot \sigma(g(Y))
+        (where f and g are feature maps and \sigma is activation function)
+        can be simplified to the form
+        .. math::
+            X \dot g(Y)
+        Using this idea, all the nonlinear activations are replaced by
+            a series of Hadamard produces
 
-    Reference:
-    
-    1. [Simple Baselines for Image Restoration](https://arxiv.org/abs/2204.04676)
+        Reference:
 
-    Parameters:
-<<<<<<< HEAD
-=======
-        input_channels (Optional[int]): number of channels in the input (as NAFBlock retains the input size in the output)
->>>>>>> ea3089f6eb211c37a2a28eb183312fd8a0c1d106
-        factor (Optional[float]): factor by which the channels must be increased before being reduced by simple gate.
-            (Higher factor denotes higher order polynomial in multiplication. Default factor is 2)
-        drop_out_rate (Optional[float]): dropout rate
-            Default value is 0.0
-        balanced_skip_connection (Optional[bool]): adds additional trainable parameters to the skip connections.
-            The parameter denotes how much importance should be given to the sub block in the skip connection.
-            Default value is False
-        mode (Optional[str]): NAFBlock has 3 mode.
-            'plain' mode uses the PlainBlock.
-                It is derived from the restormer block, keeping the most common components
-            'baseline' mode used the BaselineBlock
-                It is derived by adding layer normalization, channel attention to PlainBlock.
-                It also replaces ReLU activation with GeLU in PlainBlock.
-            'nafblock' mode uses the NAFBlock
-                It derived from BaselineBlock by removing all the non-linear activation.
-                Non-linear activations are replaced by equivalent matrix multiplication operations.
-            Default mode is 'nafblock'
+        1. [Simple Baselines for Image Restoration](https://arxiv.org/abs/2204.04676)
+
+        Parameters:
+    <<<<<<< HEAD
+    =======
+            input_channels (Optional[int]): number of channels in the input (as NAFBlock retains the input size in the output)
+    >>>>>>> ea3089f6eb211c37a2a28eb183312fd8a0c1d106
+            factor (Optional[float]): factor by which the channels must be increased before being reduced by simple gate.
+                (Higher factor denotes higher order polynomial in multiplication. Default factor is 2)
+            drop_out_rate (Optional[float]): dropout rate
+                Default value is 0.0
+            balanced_skip_connection (Optional[bool]): adds additional trainable parameters to the skip connections.
+                The parameter denotes how much importance should be given to the sub block in the skip connection.
+                Default value is False
+            mode (Optional[str]): NAFBlock has 3 mode.
+                'plain' mode uses the PlainBlock.
+                    It is derived from the restormer block, keeping the most common components
+                'baseline' mode used the BaselineBlock
+                    It is derived by adding layer normalization, channel attention to PlainBlock.
+                    It also replaces ReLU activation with GeLU in PlainBlock.
+                'nafblock' mode uses the NAFBlock
+                    It derived from BaselineBlock by removing all the non-linear activation.
+                    Non-linear activations are replaced by equivalent matrix multiplication operations.
+                Default mode is 'nafblock'
     """
 
     def __init__(

--- a/restorers/model/nafnet/nafnet.py
+++ b/restorers/model/nafnet/nafnet.py
@@ -23,7 +23,7 @@ class PixelShuffle(keras.layers.Layer):
     Reference: https://www.tensorflow.org/api_docs/python/tf/nn/depth_to_space
 
     Parameters:
-        upscale_factor: the factor by which the input's spatial dimensions will be scaled.
+        upscale_factor (int): the factor by which the input's spatial dimensions will be scaled.
     """
 
     def __init__(self, upscale_factor: int, **kwargs) -> None:
@@ -54,8 +54,8 @@ class UpScale(keras.layers.Layer):
     While giving input, make sure that (pixel_shuffle_factor**2) divides channels
 
     Parameters:
-        channels: number of channels in the input.
-        pixel_shuffle_factor: the factor by which the input's spatial dimensions will be scaled.
+        channels (int): number of channels in the input.
+        pixel_shuffle_factor (int): the factor by which the input's spatial dimensions will be scaled.
     """
 
     def __init__(self, channels: int, pixel_shuffle_factor: int, **kwargs) -> None:
@@ -103,12 +103,13 @@ class NAFNet(keras.models.Model):
     to add your own implementation for these blocks. Overwrite get_blocks to use your custom block
     in NAFNet. But make sure to follow the restrictions on these methods and blocks.
 
-    Reference: NAFNet Paper (Simple Baselines for Image Restoration)
-    https://www.ecva.net/papers/eccv_2022/papers_ECCV/papers/136670017.pdf
+    Reference:
+    
+    1. [Simple Baselines for Image Restoration](https://arxiv.org/abs/2204.04676)
 
     Parameters:
-        filters: denotes the starting filter size.
-        middle_block_num: (int) denotes the number of middle blocks.
+        filters (Optional[int]): denotes the starting filter size.
+        middle_block_num: (Optional[int]) denotes the number of middle blocks.
             Each middle block is a single NAFBlock unit.
         encoder_block_nums: (tuple) the tuple size denotes the number of encoder blocks.
             Each tuple entry denotes the number of NAFBlocks in the corresponding encoder block.

--- a/restorers/model/nafnet/nafnet.py
+++ b/restorers/model/nafnet/nafnet.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Type
+from typing import Tuple, Type
 
 import tensorflow as tf
 from tensorflow import keras
@@ -107,25 +107,29 @@ class NAFNet(keras.models.Model):
     https://www.ecva.net/papers/eccv_2022/papers_ECCV/papers/136670017.pdf
 
     Parameters:
-        filters: denotes the starting filter size.
-        middle_block_num: (int) denotes the number of middle blocks.
-            Each middle block is a single NAFBlock unit.
-        encoder_block_nums: (tuple) the tuple size denotes the number of encoder blocks.
+        filters (Optional[int]): denotes the starting filter size.
+            Default filters' size is 16 .
+        middle_block_num (Optional[int]): denotes the number of middle blocks.
+            Each middle block is a single NAFBlock unit. Default value is 1.
+        encoder_block_nums (tuple): the tuple size denotes the number of encoder blocks.
             Each tuple entry denotes the number of NAFBlocks in the corresponding encoder block.
             len(encoder_block_nums) should be the same as the len(decoder_block_nums)
-        decoder_block_nums: (tuple) the tuple size denotes the number of decoder blocks.
+            Default value is (1,1,1,1).
+        decoder_block_nums (tuple): the tuple size denotes the number of decoder blocks.
             Each tuple entry denotes the number of NAFBlocks in the corresponding decoder block.
             len(decoder_block_nums) should be the same as the len(encoder_block_nums)
-        block_type: (str) denotes what block to use in NAFNet
+            Default value is (1,1,1,1).
+        block_type (str): denotes what block to use in NAFNet
+            Default block is 'nafblock'
     """
 
     def __init__(
         self,
-        filters: Optional[int] = 16,
-        middle_block_num: Optional[int] = 1,
-        encoder_block_nums: Optional[Tuple[int]] = (1, 1, 1, 1),
-        decoder_block_nums: Optional[Tuple[int]] = (1, 1, 1, 1),
-        block_type: Optional[str] = NAFBLOCK,
+        filters: int = 16,
+        middle_block_num: int = 1,
+        encoder_block_nums: Tuple[int] = (1, 1, 1, 1),
+        decoder_block_nums: Tuple[int] = (1, 1, 1, 1),
+        block_type: str = NAFBLOCK,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -199,7 +203,7 @@ class NAFNet(keras.models.Model):
     def create_encoder_and_down_blocks(
         self,
         channels: int,
-        encoder_block_nums: Optional[Tuple[int]],
+        encoder_block_nums: Tuple[int],
     ) -> int:
         """
         Creates equal number of encoder blocks and down blocks.
@@ -226,7 +230,7 @@ class NAFNet(keras.models.Model):
     def create_decoder_and_up_blocks(
         self,
         channels: int,
-        decoder_block_nums: Optional[Tuple[int]],
+        decoder_block_nums: Tuple[int],
     ) -> int:
         """
         Creates equal number of decoder blocks and up blocks.

--- a/restorers/model/nafnet/nafnet.py
+++ b/restorers/model/nafnet/nafnet.py
@@ -20,6 +20,10 @@ class PixelShuffle(keras.layers.Layer):
     )
 
     Wrapper Class for tf.nn.depth_to_space
+    Reference: https://www.tensorflow.org/api_docs/python/tf/nn/depth_to_space
+
+    Parameters:
+        upscale_factor: the factor by which the input's spatial dimensions will be scaled.
     """
 
     def __init__(self, upscale_factor: int, **kwargs) -> None:
@@ -48,6 +52,10 @@ class UpScale(keras.layers.Layer):
         channels//(pixel_shuffle_factor**2)
     )
     While giving input, make sure that (pixel_shuffle_factor**2) divides channels
+
+    Parameters:
+        channels: number of channels in the input.
+        pixel_shuffle_factor: the factor by which the input's spatial dimensions will be scaled.
     """
 
     def __init__(self, channels: int, pixel_shuffle_factor: int, **kwargs) -> None:
@@ -94,6 +102,9 @@ class NAFNet(keras.models.Model):
     Overwrite create_encoder_and_down_blocks, create_decoder_and_up_blocks, create_middle_blocks
     to add your own implementation for these blocks. Overwrite get_blocks to use your custom block
     in NAFNet. But make sure to follow the restrictions on these methods and blocks.
+
+    Reference: NAFNet Paper (Simple Baselines for Image Restoration)
+    https://www.ecva.net/papers/eccv_2022/papers_ECCV/papers/136670017.pdf
 
     Parameters:
         filters: denotes the starting filter size.

--- a/restorers/model/nafnet/nafnet.py
+++ b/restorers/model/nafnet/nafnet.py
@@ -104,7 +104,7 @@ class NAFNet(keras.models.Model):
     in NAFNet. But make sure to follow the restrictions on these methods and blocks.
 
     Reference:
-    
+
     1. [Simple Baselines for Image Restoration](https://arxiv.org/abs/2204.04676)
 
     Parameters:


### PR DESCRIPTION
Fixes #61 

Changes proposed by this PR :-

Added references to the doctrings for [SimpleGate](https://github.com/TrystAI/restorers/blob/main/restorers/model/nafnet/nafblock.py#L11).
 Elaborated docstrings for [ChannelAttention](https://github.com/TrystAI/restorers/blob/main/restorers/model/nafnet/nafblock.py#L37) with references and more details.
 Elaborated docstrings for [SimplifiedChannelAttention](https://github.com/TrystAI/restorers/blob/main/restorers/model/nafnet/nafblock.py#L71) with references and more details.
 Elaborated docstrings for [NAFBlock](https://github.com/TrystAI/restorers/blob/main/restorers/model/nafnet/nafblock.py#L100) with references and more details.
 Added references and parameters to the docstrings for [PixelShuffle](https://github.com/TrystAI/restorers/blob/main/restorers/model/nafnet/nafnet.py#L10).
 Added parameters to the docstrings for [UpScale](https://github.com/TrystAI/restorers/blob/main/restorers/model/nafnet/nafnet.py#L39).
 Added references to the docstrings for [NAFNet](https://github.com/TrystAI/restorers/blob/main/restorers/model/nafnet/nafnet.py#L85).

Request for Review: @soumik12345 @SauravMaheshkar 
